### PR TITLE
Add "EXPOSE 8000" to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ RUN true && \
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
+EXPOSE 8000
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["rating-api"]


### PR DESCRIPTION
This is apparently needed by Gitlab CI to verify the service container
started.